### PR TITLE
Enable node integration by default

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -62,7 +62,10 @@ function createWindow () {
   mainWindow = new BrowserWindow({
     width: 1100,
     height: 700,
-    title: cmdArgs.file ? `OpenFPC - ${cmdArgs.file}` : "OpenFPC"
+    title: cmdArgs.file ? `OpenFPC - ${cmdArgs.file}` : "OpenFPC",
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
 
   mainWindow.loadURL(url.format({


### PR DESCRIPTION
This fixes the `require` behavior in newer flavors of electron; we directly require the fs module and a few others.